### PR TITLE
Add GitHub repository link to homepage

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -98,7 +98,8 @@
       "WebFetch(domain:opennext.js.org)",
       "Bash(diff:*)",
       "WebFetch(domain:developers.cloudflare.com)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "Bash(git pull:*)"
     ],
     "deny": []
   }

--- a/apps/web/app/page.test.tsx
+++ b/apps/web/app/page.test.tsx
@@ -324,6 +324,9 @@ describe('HomePage', () => {
 
       // Tab through interactive elements
       await user.tab()
+      expect(screen.getByRole('link', { name: /View Medlock on GitHub/i })).toHaveFocus()
+
+      await user.tab()
       expect(screen.getByRole('link', { name: /Reserve My Pod/i })).toHaveFocus()
 
       await user.tab()

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -211,7 +211,7 @@ export default function HomePage() {
         {/* Hero Section */}
         <header
           data-testid="hero-section"
-          className="relative isolate overflow-hidden pt-32 pb-24 hero-burst-animation"
+          className="relative isolate overflow-hidden pt-14 pb-24 hero-burst-animation"
           style={{
             background: `
               radial-gradient(circle at center, transparent 0 35%, rgba(53, 246, 226, 0.03) 55%),
@@ -219,6 +219,23 @@ export default function HomePage() {
             `,
           }}
         >
+          {/* GitHub Link - Subtle button in top right */}
+          <a
+            href="https://github.com/medlock-ai/medlock"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute top-6 right-6 p-2 rounded-full bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 hover:border-slate-600/50 transition-all duration-200"
+            aria-label="View Medlock on GitHub"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fillRule="evenodd"
+                d="M12 2C6.477 2 2 6.477 2 12c0 4.419 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.455-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.071 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.349-1.086.635-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.295 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.165 22 16.418 22 12c0-5.523-4.477-10-10-10z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </a>
+
           <div
             ref={parallaxRef}
             data-parallax="hero"


### PR DESCRIPTION
## Summary
- Added a subtle GitHub button in the top-right corner of the hero section
- Button features semi-transparent design with backdrop blur for a modern look
- Includes hover effects and proper accessibility attributes

## Test plan
- [x] Verify GitHub button appears in top-right of hero section
- [x] Confirm button links to https://github.com/medlock-ai/medlock
- [x] Test hover effects work as expected
- [x] Ensure button is properly positioned on mobile and desktop views

🤖 Generated with [Claude Code](https://claude.ai/code)