### PR TITLE
refactor: change custom domain from api.medlock.ai to mcp.medlock.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ wrangler kv namespace create WAITLIST_KV
 5. **Create GitHub OAuth App** ([github.com/settings/developers](https://github.com/settings/developers)):
 
 - Homepage: `https://your-domain.com`
-- Callback: `https://api.your-domain.com/auth/callback`
+- Callback: `https://mcp.your-domain.com/auth/callback`
 
 6. **Generate secure signing key**:
 

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -80,7 +80,7 @@ app.get('/test-auth', authMiddleware, (c) => {
 const getGitHubAuthUrl = (env: Bindings, state: string) => {
   const params = new URLSearchParams({
     client_id: env.OAUTH_CLIENT_ID,
-    redirect_uri: `${env.BASE_URL || 'https://api.medlock.ai'}/auth/callback`,
+    redirect_uri: `${env.BASE_URL || 'https://mcp.medlock.ai'}/auth/callback`,
     scope: 'user:email',
     state: state,
   })

--- a/apps/mcp/src/tools/vitals-scan.ts
+++ b/apps/mcp/src/tools/vitals-scan.ts
@@ -31,7 +31,7 @@ export const vitalsScan: Tool = {
     return {
       status: 'ready',
       instructions: `Please position your finger on the camera lens for ${params.duration || 30} seconds`,
-      scanUrl: `${context.env.BASE_URL || 'https://api.your-domain.com'}/scan/${params.vitalType}`,
+      scanUrl: `${context.env.BASE_URL || 'https://mcp.your-domain.com'}/scan/${params.vitalType}`,
       mockResult: {
         value: params.vitalType === 'heart_rate' ? 72 : 16,
         unit: params.vitalType === 'heart_rate' ? 'bpm' : 'breaths/min',

--- a/apps/mcp/test/auth.test.ts
+++ b/apps/mcp/test/auth.test.ts
@@ -16,7 +16,7 @@ describe('Authentication & Security', () => {
 
   it('test auth endpoint should return 401 without auth', async () => {
     const response = await worker.fetch(
-      new Request('https://api.your-domain.com/test-auth'),
+      new Request('https://mcp.your-domain.com/test-auth'),
       env,
       createExecutionContext()
     )
@@ -33,7 +33,7 @@ describe('Authentication & Security', () => {
     it('should redirect to GitHub OAuth when accessing protected endpoints without auth', async () => {
       try {
         const response = await worker.fetch(
-          new Request('https://api.your-domain.com/api/mcp', {
+          new Request('https://mcp.your-domain.com/api/mcp', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
@@ -86,7 +86,7 @@ describe('Authentication & Security', () => {
       })
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/auth/callback?code=test-code&state=test-state'),
+        new Request('https://mcp.your-domain.com/auth/callback?code=test-code&state=test-state'),
         env,
         createExecutionContext()
       )
@@ -105,7 +105,7 @@ describe('Authentication & Security', () => {
 
     it('should validate OAuth state parameter to prevent CSRF', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/auth/callback?code=test-code&state=invalid-state'),
+        new Request('https://mcp.your-domain.com/auth/callback?code=test-code&state=invalid-state'),
         env,
         createExecutionContext()
       )
@@ -125,7 +125,7 @@ describe('Authentication & Security', () => {
       global.fetch = vi.fn().mockRejectedValue(new Error('GitHub API error'))
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/auth/callback?code=test-code&state=test-state'),
+        new Request('https://mcp.your-domain.com/auth/callback?code=test-code&state=test-state'),
         env,
         createExecutionContext()
       )
@@ -150,7 +150,7 @@ describe('Authentication & Security', () => {
       )
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${expiredSessionId}`,
@@ -173,7 +173,7 @@ describe('Authentication & Security', () => {
   describe('Session Security', () => {
     it('should validate session cookie format and signature', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: 'hc_session=invalid-format',
@@ -190,7 +190,7 @@ describe('Authentication & Security', () => {
 
     it('should implement secure headers', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/health'),
+        new Request('https://mcp.your-domain.com/health'),
         env,
         createExecutionContext()
       )
@@ -206,7 +206,7 @@ describe('Authentication & Security', () => {
       // CORS middleware doesn't block requests, it just doesn't set CORS headers for disallowed origins
       // This test should check that CORS headers are not set for evil.com
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/health', {
+        new Request('https://mcp.your-domain.com/api/health', {
           method: 'GET',
           headers: {
             Origin: 'https://evil.com',
@@ -239,7 +239,7 @@ describe('Authentication & Security', () => {
       )
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/test-auth', {
+        new Request('https://mcp.your-domain.com/test-auth', {
           method: 'GET',
           headers: {
             Authorization: `Bearer ${apiKeySessionId}`,

--- a/apps/mcp/test/integration-updated.test.ts
+++ b/apps/mcp/test/integration-updated.test.ts
@@ -41,7 +41,7 @@ describe('MCP Integration Tests', () => {
   // Helper to initialize MCP session
   async function initializeMcpSession(): Promise<string> {
     const response = await worker.fetch(
-      new Request('https://api.your-domain.com/api/mcp', {
+      new Request('https://mcp.your-domain.com/api/mcp', {
         method: 'POST',
         headers: {
           Cookie: `hc_session=${sessionId}`,
@@ -100,7 +100,7 @@ describe('MCP Integration Tests', () => {
     it('should handle full MCP session lifecycle', async () => {
       // 1. Initialize MCP session
       const initResponse = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -128,7 +128,7 @@ describe('MCP Integration Tests', () => {
 
       // 2. List available tools
       const listResponse = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -152,7 +152,7 @@ describe('MCP Integration Tests', () => {
 
       // 3. Execute a tool
       const toolResponse = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -187,7 +187,7 @@ describe('MCP Integration Tests', () => {
       for (let i = 0; i < 3; i++) {
         requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${sessionId}`,
@@ -221,7 +221,7 @@ describe('MCP Integration Tests', () => {
   describe('Error Recovery', () => {
     it('should handle invalid session gracefully', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -252,7 +252,7 @@ describe('MCP Integration Tests', () => {
       for (let i = 0; i < 5; i++) {
         requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${sessionId}`,
@@ -296,7 +296,7 @@ describe('MCP Integration Tests', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -329,7 +329,7 @@ describe('MCP Integration Tests', () => {
 
     it('should require authentication for all MCP endpoints', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -360,7 +360,7 @@ describe('MCP Integration Tests', () => {
 
       // Execute a tool
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -392,7 +392,7 @@ describe('MCP Integration Tests', () => {
 
     it('should expose health check endpoint', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/health'),
+        new Request('https://mcp.your-domain.com/health'),
         env,
         createExecutionContext()
       )

--- a/apps/mcp/test/mcp-cloudflare.test.ts
+++ b/apps/mcp/test/mcp-cloudflare.test.ts
@@ -61,7 +61,7 @@ describe('Cloudflare MCP Implementation', () => {
   describe('McpAgent Integration', () => {
     it('should use McpAgent.serve() for handling MCP requests', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -91,7 +91,7 @@ describe('Cloudflare MCP Implementation', () => {
     it('should maintain session state across requests', async () => {
       // Initialize session
       const initResponse = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -118,7 +118,7 @@ describe('Cloudflare MCP Implementation', () => {
 
       // Make another request with the session ID
       const listResponse = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -149,7 +149,7 @@ describe('Cloudflare MCP Implementation', () => {
       for (let i = 0; i < 5; i++) {
         requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${sessionId}`,
@@ -204,7 +204,7 @@ describe('Cloudflare MCP Implementation', () => {
     it('should store MCP session mapping in KV', async () => {
       // Initialize MCP session
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -239,7 +239,7 @@ describe('Cloudflare MCP Implementation', () => {
   describe('Security Features', () => {
     it('should enforce authentication', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -261,7 +261,7 @@ describe('Cloudflare MCP Implementation', () => {
 
     it('should set security headers', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/health'),
+        new Request('https://mcp.your-domain.com/health'),
         env,
         createExecutionContext()
       )
@@ -276,7 +276,7 @@ describe('Cloudflare MCP Implementation', () => {
   describe('Error Handling', () => {
     it('should handle invalid JSON gracefully', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -297,7 +297,7 @@ describe('Cloudflare MCP Implementation', () => {
 
     it('should handle missing session gracefully', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,

--- a/apps/mcp/test/mcp-protocol.test.ts
+++ b/apps/mcp/test/mcp-protocol.test.ts
@@ -41,7 +41,7 @@ describe('MCP Protocol Implementation', () => {
   // Helper to initialize MCP session
   async function initializeMcpSession(): Promise<string> {
     const response = await worker.fetch(
-      new Request('https://api.your-domain.com/api/mcp', {
+      new Request('https://mcp.your-domain.com/api/mcp', {
         method: 'POST',
         headers: {
           Cookie: `hc_session=${sessionId}`,
@@ -102,7 +102,7 @@ describe('MCP Protocol Implementation', () => {
   describe('JSON-RPC 2.0 Protocol', () => {
     it('should handle JSON-RPC requests via POST endpoint', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -151,7 +151,7 @@ describe('MCP Protocol Implementation', () => {
 
     it('should validate JSON-RPC request format', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -185,7 +185,7 @@ describe('MCP Protocol Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -228,7 +228,7 @@ describe('MCP Protocol Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -263,7 +263,7 @@ describe('MCP Protocol Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -320,7 +320,7 @@ describe('MCP Protocol Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,

--- a/apps/mcp/test/rate-limiting.test.ts
+++ b/apps/mcp/test/rate-limiting.test.ts
@@ -32,7 +32,7 @@ describe('Rate Limiting & Billing', () => {
       for (let i = 0; i < 5; i++) {
         requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${sessionId}`,
@@ -108,7 +108,7 @@ describe('Rate Limiting & Billing', () => {
       for (let i = 0; i < 4; i++) {
         user1Requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${user1SessionId}`,
@@ -145,7 +145,7 @@ describe('Rate Limiting & Billing', () => {
       for (let i = 0; i < 3; i++) {
         user2Requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${user2SessionId}`,
@@ -182,7 +182,7 @@ describe('Rate Limiting & Billing', () => {
       const responses = []
       for (let i = 0; i < 4; i++) {
         const response = await worker.fetch(
-          new Request('https://api.your-domain.com/api/mcp', {
+          new Request('https://mcp.your-domain.com/api/mcp', {
             method: 'POST',
             headers: {
               Cookie: `hc_session=${sessionId}`,
@@ -232,7 +232,7 @@ describe('Rate Limiting & Billing', () => {
       // We can't easily simulate a Durable Object failure in the test environment,
       // but we can verify that requests go through when rate limiting is working
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -261,7 +261,7 @@ describe('Rate Limiting & Billing', () => {
   describe('Rate Limit Headers', () => {
     it('should include rate limit headers in responses', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -300,7 +300,7 @@ describe('Rate Limiting & Billing', () => {
       for (let i = 0; i < 5; i++) {
         requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',

--- a/apps/mcp/test/tools.test.ts
+++ b/apps/mcp/test/tools.test.ts
@@ -41,7 +41,7 @@ describe('Tools Implementation', () => {
   // Helper to initialize MCP session
   async function initializeMcpSession(): Promise<string> {
     const response = await worker.fetch(
-      new Request('https://api.your-domain.com/api/mcp', {
+      new Request('https://mcp.your-domain.com/api/mcp', {
         method: 'POST',
         headers: {
           Cookie: `hc_session=${sessionId}`,
@@ -104,7 +104,7 @@ describe('Tools Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -144,7 +144,7 @@ describe('Tools Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -182,7 +182,7 @@ describe('Tools Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -232,7 +232,7 @@ describe('Tools Implementation', () => {
       mcpSessionId = await initializeMcpSession()
 
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -268,7 +268,7 @@ describe('Tools Implementation', () => {
 
       // Execute a tool
       await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             Cookie: `hc_session=${sessionId}`,
@@ -320,7 +320,7 @@ describe('Tools Implementation', () => {
   describe('Tool Security', () => {
     it('should require authentication for tool execution', async () => {
       const response = await worker.fetch(
-        new Request('https://api.your-domain.com/api/mcp', {
+        new Request('https://mcp.your-domain.com/api/mcp', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -352,7 +352,7 @@ describe('Tools Implementation', () => {
       for (let i = 0; i < 5; i++) {
         requests.push(
           worker.fetch(
-            new Request('https://api.your-domain.com/api/mcp', {
+            new Request('https://mcp.your-domain.com/api/mcp', {
               method: 'POST',
               headers: {
                 Cookie: `hc_session=${sessionId}`,

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -56,7 +56,7 @@
    */
   "routes": [
     {
-      "pattern": "api.your-domain.com",
+      "pattern": "mcp.your-domain.com",
       "custom_domain": true,
     },
   ],
@@ -94,7 +94,7 @@
       "name": "medlock-mcp-staging",
       "routes": [
         {
-          "pattern": "api-staging.your-domain.com",
+          "pattern": "mcp-staging.your-domain.com",
           "custom_domain": true,
         },
       ],

--- a/apps/mcp/wrangler.production.jsonc
+++ b/apps/mcp/wrangler.production.jsonc
@@ -56,7 +56,7 @@
    */
   "routes": [
     {
-      "pattern": "api.medlock.ai",
+      "pattern": "mcp.medlock.ai",
       "custom_domain": true
     }
   ],
@@ -94,7 +94,7 @@
       "name": "medlock-mcp-staging",
       "routes": [
         {
-          "pattern": "api-staging.medlock.ai",
+          "pattern": "mcp-staging.medlock.ai",
           "custom_domain": true
         }
       ],


### PR DESCRIPTION
## Summary
- Changed custom domain from `api.medlock.ai` to `mcp.medlock.ai` throughout the monorepo
- Updated staging domain to `mcp-staging.medlock.ai`
- Updated all test files and documentation to reflect the new domain

## Why this change?
The new domain `mcp.medlock.ai` better reflects the MCP (Model Context Protocol) nature of the service.

## Changes Made
- **Wrangler Configuration**: Updated `wrangler.production.jsonc` to use the new domain pattern
- **OAuth Configuration**: Updated the OAuth callback URL in `src/index.ts`
- **Test Files**: Updated all test files to use `mcp.your-domain.com` instead of `api.your-domain.com`
- **Documentation**: Updated README.md to reflect the new callback URL format
- **Generic Configs**: Updated `wrangler.jsonc` placeholder domains

## Test plan
✅ All tests passing - ran `npm test` in the mcp app directory

🤖 Generated with [Claude Code](https://claude.ai/code)