### PR TITLE
README: architecture + Install-in-Claude-in-60-seconds quickstart (review-gated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://medlock.ai/api/mcp
 
 The same service also answers at `https://mcp.medlock.ai/api/mcp`. The path is `/api/mcp` on both hosts; there is no `/mcp` route, and the root of `mcp.medlock.ai` serves the site, not the protocol (probed 2026-07-08; see [Verify the endpoint yourself](#verify-the-endpoint-yourself)).
 
-**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every tool result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface has no path to presenting synthetic readings as someone's real vitals.
+**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every tool result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface is told at every layer that the readings are demo data, not someone's real vitals.
 
 ## Install in Claude in 60 seconds
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://medlock.ai/api/mcp
 
 The same service also answers at `https://mcp.medlock.ai/api/mcp`. The path is `/api/mcp` on both hosts; there is no `/mcp` route, and the root of `mcp.medlock.ai` serves the site, not the protocol (probed 2026-07-08; see [Verify the endpoint yourself](#verify-the-endpoint-yourself)).
 
-**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every `solid_fetch_vitals` result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface is told at every layer that the readings are demo data, not someone's real vitals.
+**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every successful `solid_fetch_vitals` result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface is told at every layer that the readings are demo data, not someone's real vitals.
 
 ## Install in Claude in 60 seconds
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,87 @@
 # Medlock
 
-Medlock is a pure Bun app that serves a frontend site and a Model Context Protocol server over Streamable HTTP.
+Medlock is a Model Context Protocol server for privacy-preserving personal health data access, in production since July 2025. It is a pure Bun app that serves the medlock.ai site and an MCP endpoint over Streamable HTTP from one Cloud Run service.
 
-The public deployment returns deterministic demo vitals. Private deployments can connect the same MCP tool surface to a user's Solid Pod and should configure bearer auth before exposing real data.
+The MCP endpoint is:
 
-## Stack
+```text
+https://medlock.ai/api/mcp
+```
 
-- Bun for the HTTP server, static site build, tests, and tooling
-- `@modelcontextprotocol/server` with `WebStandardStreamableHTTPServerTransport`
-- Cloud Run for production and pull request previews
-- Terraform for Google Cloud resources
-- GitHub Actions OIDC for GitOps deployment
+The same service also answers at `https://mcp.medlock.ai/api/mcp`. The path is `/api/mcp` on both hosts; there is no `/mcp` route, and the root of `mcp.medlock.ai` serves the site, not the protocol (probed 2026-07-08; see [Verify the endpoint yourself](#verify-the-endpoint-yourself)).
+
+**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every tool result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface has no path to presenting synthetic readings as someone's real vitals.
+
+## Install in Claude in 60 seconds
+
+### Claude (web, Desktop, mobile) — custom connector
+
+Steps per Anthropic's [custom connector guide](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp) (verified 2026-07-08):
+
+1. On a Pro/Max plan, go to **Customize > Connectors**. Free plans allow one connector. On Team/Enterprise, an Owner adds connectors under **Organization settings > Connectors** instead.
+2. Click **+**, then **Add custom connector**.
+3. Enter the remote MCP server URL: `https://medlock.ai/api/mcp`
+4. Click **Add**.
+5. In a chat, open the **+** menu, select **Connectors**, and toggle Medlock on.
+
+No OAuth setup is needed; the public deployment serves the anonymous demo client.
+
+### Claude Code
+
+Command syntax per the [Claude Code MCP docs](https://code.claude.com/docs/en/mcp) (verified 2026-07-08):
+
+```sh
+claude mcp add --transport http medlock https://medlock.ai/api/mcp
+
+# confirm it connected
+claude mcp list
+```
+
+For a private deployment with `MEDLOCK_MCP_TOKEN` set:
+
+```sh
+claude mcp add --transport http medlock https://your-host/api/mcp \
+  --header "Authorization: Bearer your-token"
+```
+
+## Architecture
+
+Each claim below cites the file that implements it.
+
+- **Streamable HTTP transport.** The MCP endpoint uses `WebStandardStreamableHTTPServerTransport` from `@modelcontextprotocol/server` (`src/mcp.ts`, `package.json`). `initialize` requests are answered as SSE `event: message` frames.
+- **Single request handler.** `src/server.ts` routes `/api/mcp` to the MCP transport, `/api/waitlist` to the waitlist store, and everything else to static assets, with canonical-host 308 redirects for legacy domains (`src/http.ts`, `src/config.ts`).
+- **Bearer auth for private deployments.** When `MEDLOCK_MCP_TOKEN` is set, MCP requests without the matching `Authorization: Bearer` header get 401 (`authenticate()` in `src/mcp.ts`; `src/config.ts`). Without a token, requests run as an anonymous demo client with `demo:read` scope. The `medlock://context` resource states the rule: connect real Solid Pods only through a private deployment with the token configured (`src/mcp.ts`).
+- **Origin and host allow-listing.** MCP requests from origins outside the allow-list get 403; the same applies to unrecognized `Host` values (`isTrustedOrigin`/`isTrustedHost` in `src/http.ts`, enforced in `src/mcp.ts`; defaults, including `https://claude.ai` and `https://chat.openai.com`, in `src/config.ts`). CORS headers echo only allow-listed origins.
+- **Rate limiting.** An in-memory limiter (`src/rate-limit.ts`) caps the waitlist API at 5 requests per minute per client IP (`handleWaitlist()` in `src/server.ts`). The MCP endpoint itself is not rate-limited in application code.
+- **Response headers.** Site pages, API JSON, and error responses carry a CSP with `default-src 'self'` and no `unsafe-inline`, `frame-ancestors 'none'`, COOP/CORP `same-origin`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and a Permissions-Policy disabling camera, geolocation, microphone, and payment (`SECURITY_HEADERS` in `src/http.ts`, applied via `json()`, `text()`, and the static file server in `src/server.ts`). Successful MCP protocol responses pass through the transport with allow-list CORS headers (`withCors` in `src/http.ts`) rather than the page-security set.
+- **Honest demo data.** Deterministic sample vitals (`src/vitals.ts`) with the disclosure wired through the protocol surface as described above (`src/mcp.ts`).
+- **Waitlist storage hashes what it can.** Waitlist entries store SHA-256 hashes of IP and user agent alongside the email (`src/waitlist.ts`).
+
+## MCP Surface
+
+Tools:
+
+- `solid_fetch_vitals`: returns selected read-only vitals from the demo Solid Pod data source
+- `vitals_scan`: prepares a browser scan handoff URL without activating camera hardware from the server
+
+Resource:
+
+- `medlock://context`: deployment and safety context for MCP clients
+
+## Verify the endpoint yourself
+
+A spec-correct Streamable HTTP `initialize` — a JSON-RPC POST accepting both JSON and SSE — is re-runnable against production:
+
+```sh
+curl -sS -X POST https://medlock.ai/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}}}'
+```
+
+Expected: HTTP 200 with `content-type: text/event-stream` and an `event: message` frame whose result carries `serverInfo` (`"name": "medlock"`) and instructions disclosing the demo Solid Pod data.
+
+The same probe runs in CI as a contract test: `test/initialize-probe.test.ts` starts the server and asserts the SSE response shape, `serverInfo`, the demo-data disclosure, the 403 for non-allow-listed origins, and the 401 when a bearer token is configured but absent.
 
 ## Local Development
 
@@ -34,16 +105,13 @@ The MCP endpoint is available at:
 http://localhost:3000/api/mcp
 ```
 
-## MCP Surface
+## Stack
 
-Tools:
-
-- `solid_fetch_vitals`: returns selected read-only vitals from the demo Solid Pod data source
-- `vitals_scan`: prepares a browser scan handoff URL without activating camera hardware from the server
-
-Resource:
-
-- `medlock://context`: deployment and safety context for MCP clients
+- Bun for the HTTP server, static site build, tests, and tooling
+- `@modelcontextprotocol/server` with `WebStandardStreamableHTTPServerTransport`
+- Cloud Run for production and pull request previews
+- Terraform for Google Cloud resources
+- GitHub Actions OIDC for GitOps deployment
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://medlock.ai/api/mcp
 
 The same service also answers at `https://mcp.medlock.ai/api/mcp`. The path is `/api/mcp` on both hosts; there is no `/mcp` route, and the root of `mcp.medlock.ai` serves the site, not the protocol (probed 2026-07-08; see [Verify the endpoint yourself](#verify-the-endpoint-yourself)).
 
-**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every tool result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface is told at every layer that the readings are demo data, not someone's real vitals.
+**The public deployment serves demo data and says so in the protocol itself.** Responses are deterministic demo vitals (`src/vitals.ts`), and every connecting client is told: the server's `initialize` instructions state that this deployment uses demo Solid Pod data until a user connects their own pod (`src/mcp.ts`), the `solid_fetch_vitals` tool description repeats it, every `solid_fetch_vitals` result is tagged `source: "demo-solid-pod"`, and the `medlock://context` resource reports `healthDataMode: "demo-solid-pod"`. For a health-data-shaped demo this disclosure is load-bearing: a model reading this surface is told at every layer that the readings are demo data, not someone's real vitals.
 
 ## Install in Claude in 60 seconds
 

--- a/test/initialize-probe.test.ts
+++ b/test/initialize-probe.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getRuntimeConfig } from "../src/config.ts";
+import { createHandler } from "../src/server.ts";
+import { MemoryWaitlistStore } from "../src/waitlist.ts";
+
+// Spec-correct Streamable HTTP initialize probe.
+//
+// This is the same request documented in the README quickstart and re-runnable
+// against the production endpoint (https://medlock.ai/api/mcp). It uses raw
+// fetch rather than the official client on purpose: it pins the wire contract
+// (JSON-RPC initialize POST with `Accept: application/json, text/event-stream`
+// answered as an SSE `event: message` frame) instead of whatever the client
+// library currently tolerates.
+
+const INITIALIZE_BODY = {
+  id: 1,
+  jsonrpc: "2.0",
+  method: "initialize",
+  params: {
+    capabilities: {},
+    clientInfo: { name: "medlock-initialize-probe", version: "1.0.0" },
+    protocolVersion: "2025-03-26",
+  },
+};
+
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.stop(true);
+  }
+});
+
+function serve(env: Record<string, string> = {}): URL {
+  const config = getRuntimeConfig({
+    ALLOWED_HOSTS: "localhost,127.0.0.1",
+    ALLOWED_ORIGINS: "http://localhost:3000,https://claude.ai",
+    CANONICAL_HOST: "medlock.ai",
+    DATA_DIR: ".test-data",
+    LEGACY_HOSTS: "",
+    MEDLOCK_VERSION: "test",
+    PORT: "0",
+    PUBLIC_DIR: `${import.meta.dir}/../public`,
+    ...env,
+  });
+  const server = Bun.serve({ fetch: createHandler({ config, waitlistStore: new MemoryWaitlistStore() }), port: 0 });
+  servers.push(server);
+  return new URL("/api/mcp", server.url);
+}
+
+function initialize(endpoint: URL, headers: Record<string, string> = {}): Promise<Response> {
+  return fetch(endpoint, {
+    body: JSON.stringify(INITIALIZE_BODY),
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    method: "POST",
+  });
+}
+
+function parseSseMessage(sseBody: string): { event: string; data: Record<string, unknown> } {
+  const event = sseBody.match(/^event: (.+)$/m)?.[1];
+  const data = sseBody.match(/^data: (.+)$/m)?.[1];
+  expect(event).toBeDefined();
+  expect(data).toBeDefined();
+  return { event: event as string, data: JSON.parse(data as string) as Record<string, unknown> };
+}
+
+describe("initialize probe", () => {
+  test("answers a spec-correct initialize with an SSE frame carrying serverInfo and the demo-data disclosure", async () => {
+    const response = await initialize(serve());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toStartWith("text/event-stream");
+
+    const { event, data } = parseSseMessage(await response.text());
+    expect(event).toBe("message");
+    expect(data.jsonrpc).toBe("2.0");
+    expect(data.id).toBe(1);
+
+    const result = data.result as {
+      instructions: string;
+      protocolVersion: string;
+      serverInfo: { name: string; version: string };
+    };
+    expect(result.protocolVersion).toBe("2025-03-26");
+    expect(result.serverInfo.name).toBe("medlock");
+    expect(result.serverInfo.version).toBe("test");
+    expect(result.instructions).toContain("demo Solid Pod data");
+  });
+
+  test("rejects an initialize from an origin outside the allow-list", async () => {
+    const response = await initialize(serve(), { Origin: "https://evil.example" });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  test("echoes an allow-listed origin in CORS headers", async () => {
+    const response = await initialize(serve(), { Origin: "https://claude.ai" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://claude.ai");
+  });
+
+  test("requires the bearer token when MEDLOCK_MCP_TOKEN is configured", async () => {
+    const endpoint = serve({ MEDLOCK_MCP_TOKEN: "probe-secret" });
+
+    const missing = await initialize(endpoint);
+    expect(missing.status).toBe(401);
+
+    const wrong = await initialize(endpoint, { Authorization: "Bearer wrong" });
+    expect(wrong.status).toBe(401);
+
+    const authorized = await initialize(endpoint, { Authorization: "Bearer probe-secret" });
+    expect(authorized.status).toBe(200);
+    expect(parseSseMessage(await authorized.text()).event).toBe("message");
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -45,6 +45,31 @@ describe("mcp", () => {
     expect(result.structuredContent?.source).toBe("demo-solid-pod");
     expect(result.content[0]?.type).toBe("text");
 
+    const scanResult = (await client.callTool({
+      arguments: { device: "rear" },
+      name: "vitals_scan",
+    })) as CallToolResult;
+
+    const expectedScanResult = {
+      device: "rear",
+      instructions: [
+        "Open the scan URL in a trusted browser session.",
+        "Grant camera access only after the browser explains the local processing flow.",
+        "Keep your finger still over the camera lens until the quality indicator is stable.",
+      ],
+      privacyMode: "local-first",
+      scanUrl: "https://medlock.ai/scan?device=rear",
+      status: "ready",
+      supportedMeasurements: ["heart_rate", "blood_oxygen", "respiratory_rate"],
+    };
+
+    expect(scanResult.isError).not.toBe(true);
+    expect(scanResult.structuredContent).toEqual(expectedScanResult);
+    expect(scanResult.content[0]?.type).toBe("text");
+    if (scanResult.content[0]?.type === "text") {
+      expect(JSON.parse(scanResult.content[0].text)).toEqual(expectedScanResult);
+    }
+
     await client.close();
   });
 });


### PR DESCRIPTION
Review-gated docs PR from the July 7 overnight run (WS-G). README architecture doc + "Install in Claude in 60 seconds" quickstart + the spec-correct initialize probe as an in-repo contract test. FACTS.md references: S3 (production MCP server, live July 2025), F10 (endpoint ambiguity — resolved by probe below), R8 (live-probe posture facts), C7 (no security-posture cleanliness claims anywhere in this diff).

## Probe evidence (2026-07-08, ~02:18 UTC)

Request used for all probes:

```
POST <endpoint>
Content-Type: application/json
Accept: application/json, text/event-stream

{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ws-g-probe","version":"1.0.0"}}}
```

| Probe | Result |
| --- | --- |
| `POST https://medlock.ai/api/mcp` | **200**, `content-type: text/event-stream`, `event: message` with `result.protocolVersion: "2025-03-26"`, `serverInfo: {"name":"medlock","version":"0.2.0","websiteUrl":"https://medlock.ai"}`, instructions: "…This deployment uses demo Solid Pod data until a user connects their own pod; never treat returned readings as medical advice." |
| `POST https://mcp.medlock.ai/api/mcp` | **200**, identical spec-correct SSE initialize |
| `POST https://mcp.medlock.ai` (root) | 200 `text/html` — the site, not an MCP endpoint |
| `POST https://mcp.medlock.ai/mcp` | **404** |
| `/api/mcp` with `Origin: https://claude.ai` | 200 + `access-control-allow-origin: https://claude.ai` + `vary: Origin` |
| `/api/mcp` with `Origin: https://evil.example` | **403** (origin allow-listing confirmed live) |

Resolution of the F10 ambiguity: the MCP path is `/api/mcp` on both hosts; the README cites `https://medlock.ai/api/mcp` (canonical host per `src/config.ts` and `infra/terraform/prod/variables.tf`) and notes the `mcp.medlock.ai/api/mcp` alias explicitly.

## Claim → file path

| README claim | Verified against |
| --- | --- |
| Streamable HTTP transport, initialize answered as SSE `event: message` | `src/mcp.ts` (`WebStandardStreamableHTTPServerTransport`), `package.json`; live probe above |
| Routing: `/api/mcp`, `/api/waitlist`, static, 308 canonical redirects | `src/server.ts`, `src/http.ts`, `src/config.ts` |
| Bearer auth when `MEDLOCK_MCP_TOKEN` set; anonymous `demo:read` client otherwise; 401 on missing/wrong token | `authenticate()` in `src/mcp.ts`, `src/config.ts`; asserted in `test/initialize-probe.test.ts` |
| Origin + host allow-listing, 403 outside list, CORS echo only for allow-listed origins | `isTrustedOrigin`/`isTrustedHost`/`corsHeaders` in `src/http.ts`, defaults in `src/config.ts`, enforcement in `src/mcp.ts`; live probes above |
| Rate limiting: waitlist API 5 req/60s per IP; MCP endpoint not rate-limited in app code | `src/rate-limit.ts`, `handleWaitlist()` in `src/server.ts` |
| CSP/header set on pages, API JSON, errors; MCP protocol responses carry CORS instead | `SECURITY_HEADERS`/`withCors` in `src/http.ts`; live probe headers (SSE 200 has CORS, no CSP; 403/404 carry full CSP set) |
| Demo-data disclosure in initialize instructions, tool description, `solid_fetch_vitals` result `source` tag, `medlock://context` | `src/mcp.ts`, `src/vitals.ts`; live probe instructions field |
| Waitlist stores SHA-256 hashes of IP/user-agent | `src/waitlist.ts` |
| Custom-connector steps + UI strings | support.claude.com article 11175166 ("Get started with custom connectors using remote MCP"), fetched 2026-07-08 |
| `claude mcp add --transport http …` / `--header "Authorization: Bearer …"` / `claude mcp list` | code.claude.com/docs/en/mcp, fetched 2026-07-08 |
| "In production since July 2025" | FACTS.md S3 (BULLETPROOF at grade) |

## Verify output

```
$ bun run verify
$ bun run tools/format.ts
$ bun run tools/lint.ts
$ tsc --noEmit
$ bun test
 12 pass
 0 fail
 48 expect() calls
Ran 12 tests across 4 files. [116.00ms]
$ bun run tools/build.ts
```

(8 pre-existing tests + 4 new in `test/initialize-probe.test.ts`.)

## Flags

- F10's "rate limits" is narrowed in the README to what the code shows: the in-memory limiter guards `/api/waitlist` only; `/api/mcp` has no application-level rate limit. If MCP-level limiting is wanted, that is server-code work outside this PR's scope.
- make_the_case.md's bare "mcp.medlock.ai" is not an endpoint URL: its root serves HTML and `/mcp` 404s. Anything citing the MCP endpoint should use `https://medlock.ai/api/mcp` (or the `/api/mcp` alias host).
- Live SSE 200 responses do not carry the CSP header set (only CORS); the README states the split precisely rather than claiming CSP on every response.
- Per C7, this diff makes no security-posture cleanliness claims; it describes mechanisms with file paths only. Dependabot findings on record are untouched by this PR.


## W7 correction evidence (2026-07-10)

- Narrowed the README's universal claim from every tool result to every successful `solid_fetch_vitals` result. `vitals_scan` is a browser handoff and does not return demo readings or a `source` field; server behavior is unchanged.
- Added an official-client regression call for `vitals_scan` that pins its documented handoff shape in both `structuredContent` and text content.
- `bun run verify`: format, lint, TypeScript, 12 tests / 0 failures / 52 expectations, and build all passed at `5b3fbac`.


**Do not merge before morning review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
